### PR TITLE
Choice of the make command, "make" or "gmake"

### DIFF
--- a/SOURCES/data_encryption/makedencryption.sh
+++ b/SOURCES/data_encryption/makedencryption.sh
@@ -11,6 +11,14 @@
 PGVERSION=$1
 SPATH=$2
 
+#use "gmake" command if installed
+if [ ! -z "`which gmake`" ];
+then
+  MAKE=gmake
+else
+  MAKE=make
+fi
+
 cd $PGVERSION
 CDIR=`pwd`
 
@@ -21,8 +29,8 @@ then
 fi
 
 #build data_encryption
-make clean
-make PGSQL_SRC_PATH=${SPATH}
+${MAKE} clean
+${MAKE} PGSQL_SRC_PATH=${SPATH}
 mv data_encryption.so data_encryption${PGVERSION}.so
 ldd data_encryption${PGVERSION}.so
 


### PR DESCRIPTION
デフォルトのmakeコマンドがGNU Makeではない環境(BSD等)に対応するため、gmakeコマンドがインストールされている場合はそれを利用するようにしました。
修正内容に問題がなければマージしていただけると幸いです。
